### PR TITLE
Add DD Prisma Tags

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/context.rs
+++ b/query-engine/connectors/sql-query-connector/src/context.rs
@@ -28,4 +28,12 @@ impl<'a> Context<'a> {
     pub(crate) fn schema_name(&self) -> &str {
         self.connection_info.schema_name()
     }
+
+    pub(crate) fn dbname(&self) -> Option<&str> {
+        self.connection_info.dbname()
+    }
+
+    pub(crate) fn db_host(&self) -> &str {
+        self.connection_info.host()
+    }
 }

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -73,7 +73,7 @@ async fn generate_id(
 
     // db generate values only if needed
     if need_select {
-        let pk_select = id_select.add_trace_id(ctx.trace_id);
+        let pk_select = id_select.add_trace_id(ctx);
         let pk_result = conn.query(pk_select.into()).await?;
         let result = try_convert(&(id_field.into()), pk_result)?;
 

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
@@ -100,7 +100,7 @@ impl SelectDefinition for QueryArguments {
             .so_that(conditions)
             .offset(skip as usize)
             .append_trace(&Span::current())
-            .add_trace_id(ctx.trace_id);
+            .add_trace_id(ctx);
 
         let select_ast = order_by_definitions
             .iter()
@@ -137,7 +137,7 @@ where
     let (select, additional_selection_set) = query.into_select(model, virtual_selections, ctx);
     let select = columns.fold(select, |acc, col| acc.column(col));
 
-    let select = select.append_trace(&Span::current()).add_trace_id(ctx.trace_id);
+    let select = select.append_trace(&Span::current()).add_trace_id(ctx);
 
     additional_selection_set
         .into_iter()
@@ -183,7 +183,7 @@ pub(crate) fn aggregate(
     selections.iter().fold(
         Select::from_table(sub_table)
             .append_trace(&Span::current())
-            .add_trace_id(ctx.trace_id),
+            .add_trace_id(ctx),
         |select, next_op| match next_op {
             AggregationSelection::Field(field) => select.column(
                 Column::from(field.db_name().to_owned())
@@ -269,7 +269,7 @@ pub(crate) fn group_by_aggregate(
     });
 
     let grouped = group_by.into_iter().fold(
-        select_query.append_trace(&Span::current()).add_trace_id(ctx.trace_id),
+        select_query.append_trace(&Span::current()).add_trace_id(ctx),
         |query, field| query.group_by(field.as_column(ctx)),
     );
 

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -34,7 +34,7 @@ pub(crate) fn create_record(
     Insert::from(insert)
         .returning(selected_fields.as_columns(ctx).map(|c| c.set_is_selected(true)))
         .append_trace(&Span::current())
-        .add_trace_id(ctx.trace_id)
+        .add_trace_id(ctx)
 }
 
 /// `INSERT` new records into the database based on the given write arguments,
@@ -84,7 +84,7 @@ pub(crate) fn create_records_nonempty(
     let insert = Insert::multi_into(model.as_table(ctx), columns);
     let insert = values.into_iter().fold(insert, |stmt, values| stmt.values(values));
     let insert: Insert = insert.into();
-    let mut insert = insert.append_trace(&Span::current()).add_trace_id(ctx.trace_id);
+    let mut insert = insert.append_trace(&Span::current()).add_trace_id(ctx);
 
     if let Some(selected_fields) = selected_fields {
         insert = insert.returning(projection_into_columns(selected_fields, ctx));
@@ -105,7 +105,7 @@ pub(crate) fn create_records_empty(
     ctx: &Context<'_>,
 ) -> Insert<'static> {
     let insert: Insert<'static> = Insert::single_into(model.as_table(ctx)).into();
-    let mut insert = insert.append_trace(&Span::current()).add_trace_id(ctx.trace_id);
+    let mut insert = insert.append_trace(&Span::current()).add_trace_id(ctx);
 
     if let Some(selected_fields) = selected_fields {
         insert = insert.returning(projection_into_columns(selected_fields, ctx));
@@ -175,7 +175,7 @@ pub(crate) fn build_update_and_set_query(
             acc.set(name, value)
         });
 
-    let query = query.append_trace(&Span::current()).add_trace_id(ctx.trace_id);
+    let query = query.append_trace(&Span::current()).add_trace_id(ctx);
 
     let query = if let Some(selected_fields) = selected_fields {
         query.returning(selected_fields.as_columns(ctx).map(|c| c.set_is_selected(true)))
@@ -222,7 +222,7 @@ pub(crate) fn delete_returning(
         .so_that(filter)
         .returning(projection_into_columns(selected_fields, ctx))
         .append_trace(&Span::current())
-        .add_trace_id(ctx.trace_id)
+        .add_trace_id(ctx)
         .into()
 }
 
@@ -234,7 +234,7 @@ pub(crate) fn delete_many_from_filter(
     Delete::from_table(model.as_table(ctx))
         .so_that(filter_condition)
         .append_trace(&Span::current())
-        .add_trace_id(ctx.trace_id)
+        .add_trace_id(ctx)
         .into()
 }
 
@@ -301,5 +301,5 @@ pub(crate) fn delete_relation_table_records(
     Delete::from_table(relation.as_table(ctx))
         .so_that(parent_id_criteria.and(child_id_criteria))
         .append_trace(&Span::current())
-        .add_trace_id(ctx.trace_id)
+        .add_trace_id(ctx)
 }

--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -36,7 +36,7 @@ impl<Q: Queryable + ?Sized> QueryExt for Q {
                 Query::Select(Box::from(x.comment(trace_parent_to_string(span_ctx))))
             }
             // This is part of the required changes to pass a traceid
-            (Query::Select(x), trace_id) => Query::Select(Box::from(x.add_trace_id(trace_id))),
+            (Query::Select(x), _) => Query::Select(Box::from(x.add_trace_id(ctx))),
             (q, _) => q,
         };
 
@@ -134,7 +134,7 @@ impl<Q: Queryable + ?Sized> QueryExt for Q {
         let select = Select::from_table(model.as_table(ctx))
             .columns(id_cols)
             .append_trace(&Span::current())
-            .add_trace_id(ctx.trace_id)
+            .add_trace_id(ctx)
             .so_that(condition);
 
         self.select_ids(select, model_id, ctx).await

--- a/query-engine/connectors/sql-query-connector/src/sql_trace.rs
+++ b/query-engine/connectors/sql-query-connector/src/sql_trace.rs
@@ -2,6 +2,52 @@ use opentelemetry::trace::{SpanContext, TraceContextExt, TraceFlags};
 use quaint::ast::{Delete, Insert, Select, Update};
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
+use crate::Context;
+use std::sync::OnceLock;
+
+static ENV: OnceLock<String> = OnceLock::new();
+static SERVICE: OnceLock<String> = OnceLock::new();
+static VERSION: OnceLock<String> = OnceLock::new();
+
+// We assume that if the relevant env vars aren't set, we must be running locally
+fn get_env() -> &'static str {
+    ENV.get_or_init(|| std::env::var("DD_ENV").unwrap_or_else(|_| "development".to_string()))
+}
+
+fn get_service() -> &'static str {
+    SERVICE.get_or_init(|| std::env::var("DD_SERVICE").unwrap_or_else(|_| "development".to_string()))
+}
+
+fn get_version() -> &'static str {
+    VERSION.get_or_init(|| std::env::var("DD_VERSION").unwrap_or_else(|_| "development".to_string()))
+}
+
+fn get_dd_tag_string(ctx: &Context<'_>) -> String {
+    // Prisma doesn't support datadog dbm tags in the query comments, so we've added them here.
+    // See https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/database.js#L31
+    // for the tags that are used by the postgres datadog plugin as an example.
+    let dbname = ctx.dbname().unwrap_or("unknown");
+    let db_host = ctx.db_host();
+    // We don't want to thread the database_service through the prisma client and prisma engine,
+    // so we just hard code our known databases here and infer the db service name from the host.
+    let database_service = if db_host.contains("main-db") {
+        "main-db"
+    } else if db_host.contains("analytics-db") {
+        "analytics-db"
+    } else if db_host.contains("codebase-aurora") {
+        "codebase-db"
+    } else if db_host.contains("mysql-db") {
+        "mysql-db"
+    } else {
+        "unknown"
+    };
+    let env = get_env();
+    let parent_service = get_service();
+    let parent_version = get_version();
+    return format!("dddb='{}',dddbs='{}',dde='{}',ddh='{}',ddps='{}',ddpv='{}'",
+        dbname, database_service, db_host, env, parent_service, parent_version)
+}
+
 
 pub fn trace_parent_to_string(context: &SpanContext) -> String {
     let trace_id = context.trace_id();
@@ -13,7 +59,7 @@ pub fn trace_parent_to_string(context: &SpanContext) -> String {
 
 pub trait SqlTraceComment: Sized {
     fn append_trace(self, span: &Span) -> Self;
-    fn add_trace_id(self, trace_id: Option<&str>) -> Self;
+    fn add_trace_id(self, ctx: &Context<'_>) -> Self;
 }
 
 macro_rules! sql_trace {
@@ -31,15 +77,17 @@ macro_rules! sql_trace {
                 }
             }
             // Temporary method to pass the traceid in an operation
-            fn add_trace_id(self, trace_id: Option<&str>) -> Self {
-                if let Some(traceparent) = trace_id {
+            fn add_trace_id(self, ctx: &Context<'_>) -> Self {
+                // Always add the dd tags so we at least get service info, even if there's not an active trace.
+                let dd_tag_string = get_dd_tag_string(ctx);
+                if let Some(traceparent) = ctx.trace_id {
                     if should_sample(&traceparent) {
-                        self.comment(format!("traceparent='{}'", traceparent))
+                        self.comment(format!("{},traceparent='{}'", dd_tag_string, traceparent))
                     } else {
-                        self
+                        self.comment(dd_tag_string)
                     }
                 } else {
-                    self
+                    self.comment(dd_tag_string)
                 }
             }
         }


### PR DESCRIPTION
Adds the DD tags using the DD env vars, or the db name/host from the connecting string.

Always adds the DD tags, even if the trace is not active because we can still get service-databse correlated metrics even if we don't have traces.

This shouldn't affect the statement cache much because the DD tags should be the same for every (service, database) pair.